### PR TITLE
Tiny bug on dropdown select

### DIFF
--- a/index.js
+++ b/index.js
@@ -196,7 +196,11 @@ const displayDetailsLabel = (e, eventObj) => {
   dropdown.append(select, interested, going, notgoing)
   label.append(dropdown)
 
-  dropdown.value = getStatus[status]
+  if(status){
+    dropdown.value = getStatus[status]
+  } else {
+    dropdown.value = ""
+  }
 
   detailFooter.append(label, attendSpan)
 }


### PR DESCRIPTION
If nothing had been selected yet status read as null, so getStatus[status] was undefined and drop down was empty instead of having "select one" as default. Add if statement to check that status exists, otherwise default dropdown to "select one".